### PR TITLE
zona horaria

### DIFF
--- a/app/Http/Controllers/BautismoController.php
+++ b/app/Http/Controllers/BautismoController.php
@@ -56,9 +56,9 @@ class BautismoController extends Controller
         $diab = Carbon::parse($bautismo->fecha_celebracion)->format('d');
         $mesb = Carbon::parse($bautismo->fecha_celebracion)->isoFormat('MMMM');
         $añob = Carbon::parse($bautismo->fecha_celebracion)->isoFormat('Y');
-        $diac = Carbon::now()->isoFormat('DD');
-        $mesc = Carbon::now()->isoFormat('MMMM');
-        $anoc = Carbon::now()->isoFormat('Y');
+        $diac = Carbon::now('America/La_Paz')->isoFormat('DD');
+        $mesc = Carbon::now('America/La_Paz')->isoFormat('MMMM');
+        $anoc = Carbon::now('America/La_Paz')->isoFormat('Y');
     
 
         $pdf = PDF::loadView('menu.bautismos.print', ['bautismo' => $bautismo, 'parroquia' => $parroquias,  'dian' => $dian, 'mesn' => $mesn, 'anon' => $anon, 'diab' => $diab, 'mesb' => $mesb, 'anob' => $añob, 'diac' => $diac, 'mesc' => $mesc, 'anoc' => $anoc ]);


### PR DESCRIPTION
se agrego zona horario de La Paz para cuando se valla a imprimir la fecha actual, coincida con la de RD ya que verificamos zona horaria tenia 4 horas de adelanto por lo que actas impresas en la noche podian salir con la fecha del dia siguiente