### PR TITLE
agregar mensaje de error input celebrante

### DIFF
--- a/resources/views/livewire/crear-acta.blade.php
+++ b/resources/views/livewire/crear-acta.blade.php
@@ -88,7 +88,10 @@
             <x-input-label for="celebrante_name" :value="__('celebrante')" />
     
             <x-text-input id="celebrante_name" class="block mt-1 w-full" type="text" wire:model="celebrante_name" :value="old('celebrante_name')" placeholder="Ej. Rev. P. Juan Perez"/>
-    
+            
+            @error('celebrante_name')
+            <livewire:mostrar-alertas :message="$message" />
+            @enderror
         </div>
 
 


### PR DESCRIPTION
campo celebrante no mostraba mensaje de error al no cumplirse los parametros de validacion, se corrigio