### PR TITLE
formulario acta bautismo

### DIFF
--- a/app/Http/Livewire/CrearActa.php
+++ b/app/Http/Livewire/CrearActa.php
@@ -39,6 +39,8 @@ class CrearActa extends Component
     public $fecha_celebracion;
     public $notas;
     public $comunidades;
+    public $parroquias;
+    public $ubicacion;
 
     protected $rules = [
         
@@ -58,8 +60,8 @@ class CrearActa extends Component
         'año' => 'required|string',
         'circunscripcion' => 'required|string',
         'oficialia' => 'required|string',
-        'parroquia' => 'required',
-        'ub_parroquia' => 'required|string',
+        //'parroquia' => 'required',
+        //'ub_parroquia' => 'required|string',
         'celebrante_name' => 'required|string',
         'fecha_celebracion' => 'required',
         'notas' => 'nullable|string',
@@ -71,6 +73,8 @@ class CrearActa extends Component
 
     public function crearActa(){
         $datos = $this->validate();
+        $parroquias = DB::table('parroquias')->value('parroquia');
+        $ubicacion = DB::table('parroquias')->value('ciudad');
 
         // Guardar 
 
@@ -94,8 +98,8 @@ class CrearActa extends Component
             'año'=> $datos['año'],
             'circunscripcion'=> $datos['circunscripcion'],
             'oficialia'=> $datos['oficialia'],
-            'parroquia'=> $datos['parroquia'],
-            'ub_parroquia'=> $datos['ub_parroquia'],
+            'parroquia'=> $parroquias,
+            'ub_parroquia'=> $ubicacion,
             'celebrante'=> $datos['celebrante_name'],
             'fecha_celebracion'=> $datos['fecha_celebracion'],
             'notas' => $datos['notas'],
@@ -114,14 +118,12 @@ class CrearActa extends Component
     {
         //Consultar BD para autopoblar select
 
-        $comunidades = DB::table('comunidades')->get(['nombre_comunidad', 'ubicacion']);
+       
     
        
         
 
-        return view('livewire.crear-acta', [
-           $this->comunidades = $comunidades
-        ]);
+        return view('livewire.crear-acta');
         
 
     }

--- a/resources/views/livewire/crear-acta.blade.php
+++ b/resources/views/livewire/crear-acta.blade.php
@@ -42,8 +42,8 @@
 
         <h2 class="block text-md text-gray-700 font-bold uppercase mb-2 text-center mt-2">datos de la celebración</h2>
 
-    <div class="grid grid-cols-4">
-        <div>
+    <div class="grid grid-cols-2">
+       {{-- <div>
             <x-input-label for="parroquia" :value="__('Parroquia o Capilla')" />
 
             <select wire:model="parroquia" id="parroquia" class="rounded-md shadow-sm border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 w-full">
@@ -83,6 +83,7 @@
         @enderror
     
         </div>
+        --}}
 
         <div>
             <x-input-label for="celebrante_name" :value="__('celebrante')" />


### PR DESCRIPTION
se elimino del formulario los input para parroquia y ubicacion de la parroquia, ya que los mismos siempre seran por defectos los que esten configurados en la parte de la parroquia